### PR TITLE
Remove entry warning

### DIFF
--- a/libs/remix-ui/app/src/lib/remix-app/components/modals/origin-warning.tsx
+++ b/libs/remix-ui/app/src/lib/remix-app/components/modals/origin-warning.tsx
@@ -15,15 +15,6 @@ const OriginWarning = () => {
       (window.location.hostname === 'ethereum.github.io' && window.location.pathname.indexOf('/remix-live-alpha') === 0)
     ) {
       setContent('Welcome to the Remix alpha instance. Please use it to try out latest features. But use preferably https://remix.ethereum.org for any production work.')
-    } else if (
-      window.location.protocol.indexOf('http') === 0 &&
-      window.location.hostname !== 'remix.ethereum.org' &&
-      window.location.hostname !== 'localhost' &&
-      window.location.hostname !== '127.0.0.1'
-    ) {
-      setContent(`The Remix IDE has moved to http://remix.ethereum.org.\n
-      This instance of Remix you are visiting WILL NOT BE UPDATED.\n
-      Please make a backup of your contracts and start using http://remix.ethereum.org`)
     }
   }, [])
 


### PR DESCRIPTION
Remove warning window on first entry about host moving to remix.ethereum.org