### PR TITLE
 Fix Typo in `README.md`

### DIFF
--- a/apps/learneth/README.md
+++ b/apps/learneth/README.md
@@ -42,7 +42,7 @@ Root directories are individual workshops, the name used will be the name of the
 
 ### README.md
 
-The readme in each directry contains an explanation of what the workshop is about. If an additional summary property is provided in the config.yml that will be used in the overview section of the plugin.
+The readme in each directory contains an explanation of what the workshop is about. If an additional summary property is provided in the config.yml that will be used in the overview section of the plugin.
 
 ### config.yml
 


### PR DESCRIPTION
# Fix Typo in `README.md`

## Description
This pull request resolves a typo in the `README.md` file within the `apps/learneth` directory.  
- Corrected the spelling of "directry" to "directory" in the explanation section.

### Changes Made:
- **File Modified:** `apps/learneth/README.md`
- **Summary of Changes:**
  - Line 42: Corrected "directry" to "directory."

## Related Issues
<!-- If applicable, link to any issues this PR addresses. -->
N/A

## Checklist
- [x] Code comments updated for clarity and professionalism.
- [x] Verified adherence to the project's [Contributing Guidelines](link-to-guidelines) and [Security Policy](link-to-security-policy).

## Testing
<!-- Describe how you validated the change, if applicable. -->
- N/A (Comment typo fix only)

## Additional Notes
This update is a non-functional change and is strict
